### PR TITLE
Noto Sans JP導入 #7

### DIFF
--- a/src/ejs/component/head.ejs
+++ b/src/ejs/component/head.ejs
@@ -4,3 +4,4 @@
 <title>Document</title>
 
 <link rel="stylesheet" href="css/index.css">
+<link href="https://fonts.googleapis.com/earlyaccess/notosansjapanese.css" rel="stylesheet" />

--- a/src/ejs/component/head.ejs
+++ b/src/ejs/component/head.ejs
@@ -4,4 +4,4 @@
 <title>Document</title>
 
 <link rel="stylesheet" href="css/index.css">
-<link href="https://fonts.googleapis.com/earlyaccess/notosansjapanese.css" rel="stylesheet" />
+<link href="http://fonts.googleapis.com/earlyaccess/notosansjp.css" rel="stylesheet" />


### PR DESCRIPTION
見たところ使用フォントはNoto Sans JPのみです。導入しましたので確認お願いします。
またlinkタグの設置位置効率化、githubの使い方等改善できる点あればご指摘願います。

（画像添付）
![64248b56c99073a509dc33648ab65607](https://user-images.githubusercontent.com/36566076/37867311-93ea4a44-2fd9-11e8-8002-c27f229ac708.png)
