### PR TITLE
linkタグ記法の修正（閉じスラッシュ削除・httpsへ） #7

### DIFF
--- a/src/ejs/component/head.ejs
+++ b/src/ejs/component/head.ejs
@@ -4,4 +4,4 @@
 <title>Document</title>
 
 <link rel="stylesheet" href="css/index.css">
-<link href="http://fonts.googleapis.com/earlyaccess/notosansjp.css" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/earlyaccess/notosansjp.css" rel="stylesheet">


### PR DESCRIPTION
ご指摘のあった通り、linkタグの記法を修正しました。指摘ありがとうございます。
軽微な修正だったのでbranchを戻してpull request飛ばします。確認後mergeお願いします。