### PR TITLE
年齢関係のバグを修正 #71

### DIFF
--- a/src/js/output-profile.js
+++ b/src/js/output-profile.js
@@ -15,11 +15,15 @@ function outputProfile (bDay, gender) {
   // ------年齢を算出、年齢を表示
   var age
   var bDaySplit = bDay.split('-')
-  var birthDate = new Date(bDaySplit[0], bDaySplit[1], bDaySplit[2])
+  var birthDate = new Date(bDaySplit[0], bDaySplit[1] - 1, bDaySplit[2])
   var today = new Date()
   age = today.getFullYear() - birthDate.getFullYear()
-  if (today < new Date(today.getFullYear(), birthDate.getMonth(), birthDate.getDay())) {
+  if (today < new Date(today.getFullYear(), bDaySplit[1] - 1, bDaySplit[2])) {
     age--
+  }
+  // 年齢がマイナスなら0に
+  if (age < 0) {
+    age = 0
   }
   $ageText.text(age)
 
@@ -45,8 +49,10 @@ function outputProfile (bDay, gender) {
   var isActive = false // アクティブ状態切り替え用
 
   // setTimer()を読み込み時に一度だけ実行,スクロールごとにも実行
-  setTimer()
-  $(window).on('scroll', setTimer)
+  if (age > 0) {
+    setTimer()
+    $(window).on('scroll', setTimer)
+  }
 
   function setTimer () {
     if (!(isActive)) {


### PR DESCRIPTION
年齢算出のミス、０歳以下でもランプが１つ点灯、マイナス歳が表示されてしまう
問題を修正しました

■備考
・年齢がマイナス（生年月日が未来）の時は0歳と表示します。

動作確認お願いします。
