### PR TITLE
issue No.100を修正(hero.jpgのリンクを変更) #110

### DIFF
--- a/src/ejs/component/hero.ejs
+++ b/src/ejs/component/hero.ejs
@@ -1,4 +1,4 @@
 <!-- head -->
 <div class="hero">
-  <img class="hero__img" src="../image/hero.jpg" alt="">
+  <img class="hero__img" src="/stage-2-team-mochimochi/image/hero.jpg" alt="">
 </div>


### PR DESCRIPTION
しました。他に修正点等ありましたらご指摘ください。
なお詳細ですが、github pagesは仕様上サブディレクトリが一つ挟まり、それのせいです。ただその影響で今度はテスト環境で画像が見えなくなりました。各自対応してください。

今回はURLを単純に書き換えるという簡易な手段を取りましたが、ちょっと調べたところ実はgithub pages向けにパスを書き換えてくれるプラグインがあるらしいです。 ~~たぶんいらないでしょう。~~ 判断はお任せします。