### PR TITLE
outputTweet()関数を廃止しました #121

### DIFF
--- a/src/js/output-core.js
+++ b/src/js/output-core.js
@@ -1,4 +1,4 @@
-/* global $ */
+/* global $ outputProfile outputWhat outputWhere outputFavorite */
 (function () {
   // -----パラメータを['AAA=XXX', 'BBB=YYY',...]の状態に分割
   var paramSplit = window.location.search.split('&')
@@ -23,6 +23,6 @@
     $(window).on('load', function () {
       outputWhere(paramObj.city)
     })
-    outputTweet()
+    $('.tweet').show()
   }
-})()
+})();

--- a/src/js/output-tweet.js
+++ b/src/js/output-tweet.js
@@ -1,5 +1,0 @@
-/* global $ */
-// outputTweet関数
-function outputTweet () {
-  $('.tweet').show()
-}


### PR DESCRIPTION
outputTweet()関数を廃止し、output-tweet.jsを削除しました。
また、output-coreに代替コードを記述しました。

リクエストのチェックお願いします。